### PR TITLE
fix pulsar admin cli tool

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -156,7 +156,7 @@ Flags:
       --no-wait           Skip waiting for service account readiness.
 
 #e.g:
-$ snctl auth export-service-account test-service-account-name -n test-service-account-namespace -f [/path/to/key/file.txt]
+$ snctl auth export-service-account test-service-account-name -n test-service-account-namespace -f [/path/to/key/file.json]
 ```
 
 Output:

--- a/cloud/go/README.md
+++ b/cloud/go/README.md
@@ -29,7 +29,7 @@ The consumer receives the message from the `topic-1` and `acknowledges` each rec
 ```bash
 $ go build -o consumer sampleConsumer.go
 $ ./consumer -serviceURL pulsar+ssl://cloud.streamnative.dev:6651 \
-       -privateKeyFile /path/to/private/key/file.txt\
+       -privateKeyFile /path/to/private/key/file.json\
        -audience urn:sn:pulsar:pulsar-instance-ns:pulsar-instance-name\
        -issuerUrl https://cloud.streamnative.dev\
        -clientId abcdefghigk0123456789
@@ -55,7 +55,7 @@ Received message msgId: {{10 26 0 0} <nil> 0xc0000e0160 {13817980335716792128 17
 ```bash
 $ go build -o producer sampleProdcer.go
 $ ./producer -serviceURL pulsar+ssl://cloud.streamnative.dev:6651 \
-       -privateKeyFile /path/to/private/key/file.txt\
+       -privateKeyFile /path/to/private/key/file.json\
        -audience urn:sn:pulsar:pulsar-instance-ns:pulsar-instance-name\
        -issuerUrl https://cloud.streamnative.dev\
        -clientId abcdefghigk0123456789

--- a/cloud/pulsar-admin/README.md
+++ b/cloud/pulsar-admin/README.md
@@ -12,6 +12,8 @@ The `pulsar-admin` is a CLI tool written in Java language for the Apache Pulsar 
 
 # Usage
 
+## Token
+
 The `pulsar-admin` supports to connect to Pulsar cluster through Token, as shown below:
 
 ```shell script
@@ -22,3 +24,29 @@ The `pulsar-admin` supports to connect to Pulsar cluster through Token, as shown
     tenants list
 ```
 
+Output:
+
+```text
+"public"
+"pulsar"
+```
+
+## OAuth2
+
+The `pulsar-admin` supports to connect to Pulsar cluster through OAuth2, as shown below:
+
+```shell script
+bin/pulsar-admin --admin-url https://cloud.streamnative.dev:443 \
+  --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+  --auth-params '{"privateKey":"file:///path/to/key/file.txt",
+    "issuerUrl":"https://test.auth0.com",
+    "audience":"urn:sn:pulsar:test-pulsar-instance-namespace:test-pulsar-instance"}' \
+  tenants list
+```
+
+Output:
+
+```text
+"public"
+"pulsar"
+```

--- a/cloud/pulsar-admin/README.md
+++ b/cloud/pulsar-admin/README.md
@@ -12,7 +12,7 @@ The `pulsar-admin` is a CLI tool written in Java language for the Apache Pulsar 
 
 # Usage
 
-## Token
+## Token authentication plugin
 
 The `pulsar-admin` supports to connect to Pulsar cluster through Token, as shown below:
 
@@ -31,14 +31,14 @@ Output:
 "pulsar"
 ```
 
-## OAuth2
+## OAuth2 authentication plugin
 
 The `pulsar-admin` supports to connect to Pulsar cluster through OAuth2, as shown below:
 
 ```shell script
 bin/pulsar-admin --admin-url https://cloud.streamnative.dev:443 \
   --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
-  --auth-params '{"privateKey":"file:///path/to/key/file.txt",
+  --auth-params '{"privateKey":"file:///path/to/key/file.json",
     "issuerUrl":"https://test.auth0.com",
     "audience":"urn:sn:pulsar:test-pulsar-instance-namespace:test-pulsar-instance"}' \
   tenants list

--- a/cloud/pulsar-admin/README.md
+++ b/cloud/pulsar-admin/README.md
@@ -4,9 +4,11 @@ The `pulsar-admin` is a CLI tool written in Java language for the Apache Pulsar 
 
 # Prerequisites
 
-- Pulsar broker 2.7.0-742fc5c9b+
+> Pulsar client is required to be newer than 2.6.1 which will include the OAuth2 authentication plugin.
 
-> You can get this tarball from [bintray](https://bintray.com/streamnative/maven/org.apache.pulsar/2.7.0-742fc5c9b). When Pulsar 2.6.1 is released, you can also use the official 2.6.1 version.
+- Pulsar broker 2.7.0-742fc5c9b+
+- Get the `WEB_SERVICE_URL` of your StreamNative Cloud Pulsar cluster: [How to get service URL](#How to get service URL)
+- Get the `AUTH_PARAMS` of your StreamNative Cloud Pulsar cluster: [How to get token options](#How to get token options)
 
 # Usage
 
@@ -15,8 +17,8 @@ The `pulsar-admin` supports to connect to Pulsar cluster through Token, as shown
 ```shell script
 ./bin/pulsar-admin \
     --url WEB_SERVICE_URL \
-    --auth-params AUTH_PARAMS \
+    --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+    --auth-params token:AUTH_PARAMS \
     tenants list
 ```
 
-How to get the `WEB_SERVICE_URL` and `AUTH_PARAMS` fields, please reference to **how to get Token options**.

--- a/cloud/pulsar-admin/README.md
+++ b/cloud/pulsar-admin/README.md
@@ -7,8 +7,8 @@ The `pulsar-admin` is a CLI tool written in Java language for the Apache Pulsar 
 > Pulsar client is required to be newer than 2.6.1 which will include the OAuth2 authentication plugin.
 
 - Pulsar broker 2.7.0-742fc5c9b+
-- Get the `WEB_SERVICE_URL` of your StreamNative Cloud Pulsar cluster: [How to get service URL](#How to get service URL)
-- Get the `AUTH_PARAMS` of your StreamNative Cloud Pulsar cluster: [How to get token options](#How to get token options)
+- Get the `WEB_SERVICE_URL` of your StreamNative Cloud Pulsar cluster: [How to get service URL](../README.md#How to get service URL)
+- Get the `AUTH_PARAMS` of your StreamNative Cloud Pulsar cluster: [How to get token options](../README.md#How to get token options)
 
 # Usage
 

--- a/cloud/pulsar-client/README.md
+++ b/cloud/pulsar-client/README.md
@@ -4,9 +4,11 @@ The `pulsar-client` and `pulsar-perf` are CLI tool written in Java language for 
 
 # Prerequisites
 
-- Pulsar broker 2.7.0-742fc5c9b+
+> Pulsar client is required to be newer than 2.6.1 which will include the OAuth2 authentication plugin.
 
-> You can get this tarball from [bintray](https://bintray.com/streamnative/maven/org.apache.pulsar/2.7.0-742fc5c9b). When Pulsar 2.6.1 is released, you can also use the official 2.6.1 version.
+- Pulsar broker 2.7.0-742fc5c9b+
+- Get the `SERVICE_URL` of your StreamNative Cloud Pulsar cluster: [How to get service URL](#How to get service URL)
+- Get the `AUTH_PARAMS` of your StreamNative Cloud Pulsar cluster: [How to get token options](#How to get token options)
 
 # Usage
 
@@ -15,17 +17,18 @@ The `pulsar-client` supports to connect to Pulsar cluster through Token, as show
 ```shell script
 ./bin/pulsar-client \
     --url SERVICE_URL \
-    --auth-params AUTH_PARAMS \
+    --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+    --auth-params token:AUTH_PARAMS \
     produce test-topic -m "test-message" -n 10
 ```
 
 The `pulsar-perf` supports to connect to Pulsar cluster through Token, as shown below:
 
 ```shell script
-./bin/pulsar-perf \
+./bin/pulsar-perf produce \
     --service-url SERVICE_URL \
-    --auth-params AUTH_PARAMS \
-    produce -r 1000 -s 1024 test-topic
+    --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+    --auth-params token:AUTH_PARAMS \
+    -r 1000 -s 1024 test-topic
 ```
 
-How to get the `SERVICE_URL` and `AUTH_PARAMS` fields, please reference to **how to get Token options**.

--- a/cloud/pulsar-client/README.md
+++ b/cloud/pulsar-client/README.md
@@ -7,8 +7,8 @@ The `pulsar-client` and `pulsar-perf` are CLI tool written in Java language for 
 > Pulsar client is required to be newer than 2.6.1 which will include the OAuth2 authentication plugin.
 
 - Pulsar broker 2.7.0-742fc5c9b+
-- Get the `SERVICE_URL` of your StreamNative Cloud Pulsar cluster: [How to get service URL](#How to get service URL)
-- Get the `AUTH_PARAMS` of your StreamNative Cloud Pulsar cluster: [How to get token options](#How to get token options)
+- Get the `SERVICE_URL` of your StreamNative Cloud Pulsar cluster: [How to get service URL](../README.md#How to get service URL)
+- Get the `AUTH_PARAMS` of your StreamNative Cloud Pulsar cluster: [How to get token options](../README.md#How to get token options)
 
 # Usage
 

--- a/cloud/pulsar-client/README.md
+++ b/cloud/pulsar-client/README.md
@@ -12,6 +12,8 @@ The `pulsar-client` and `pulsar-perf` are CLI tool written in Java language for 
 
 # Usage
 
+## pulsar-client
+
 The `pulsar-client` supports to connect to Pulsar cluster through Token, as shown below:
 
 ```shell script
@@ -22,13 +24,78 @@ The `pulsar-client` supports to connect to Pulsar cluster through Token, as show
     produce test-topic -m "test-message" -n 10
 ```
 
+Output:
+
+```text
+...
+12:21:50.920 [main] INFO  org.apache.pulsar.client.cli.PulsarClientTool - 10 messages successfully produced
+```
+
+The `pulsar-client` supports to connect to Pulsar cluster through OAuth2, as shown below:
+
+```shell script
+bin/pulsar-client \
+  --url SERVICE_URL \
+  --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+  --auth-params '{"privateKey":"file:///path/to/key/file.txt",
+    "issuerUrl":"https://test.auth0.com",
+    "audience":"urn:sn:pulsar:test-pulsar-instance-namespace:test-pulsar-instance"}' \
+  produce test-topic -m "test-message" -n 10
+```
+
+Output:
+
+```text
+...
+12:21:50.920 [main] INFO  org.apache.pulsar.client.cli.PulsarClientTool - 10 messages successfully produced
+```
+
+## pulsar-perf
+
 The `pulsar-perf` supports to connect to Pulsar cluster through Token, as shown below:
 
 ```shell script
 ./bin/pulsar-perf produce \
     --service-url SERVICE_URL \
-    --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+    --auth_plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
     --auth-params token:AUTH_PARAMS \
     -r 1000 -s 1024 test-topic
 ```
 
+
+Output:
+
+```text
+...
+12:12:39.350 [pulsar-client-io-2-8] INFO  org.apache.pulsar.client.impl.PartitionedProducerImpl - [test-topic] Created partitioned producer
+12:12:39.351 [pulsar-perf-producer-exec-1-1] INFO  org.apache.pulsar.testclient.PerformanceProducer - Created 1 producers
+12:12:39.379 [pulsar-timer-7-1] WARN  com.scurrilous.circe.checksum.Crc32cIntChecksum - Failed to load Circe JNI library. Falling back to Java based CRC32c provider
+12:12:39.784 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Throughput produced:      0.1  msg/s ---      0.0 Mbit/s --- failure      0.0 msg/s --- Latency: mean:   0.000 ms - med:   0.000 - 95pct:   0.000 - 99pct:   0.000 - 99.9pct:   0.000 - 99.99pct:   0.000 - Max:   0.000
+12:12:49.854 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Throughput produced:    191.4  msg/s ---      1.5 Mbit/s --- failure      0.0 msg/s --- Latency: mean: 4647.764 ms - med: 5022.815 - 95pct: 7667.007 - 99pct: 7740.223 - 99.9pct: 7755.263 - 99.99pct: 7756.639 - Max: 7756.639
+12:12:59.894 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Throughput produced:    900.4  msg/s ---      7.0 Mbit/s --- failure      0.0 msg/s --- Latency: mean: 1148.746 ms - med: 1093.679 -
+...
+```
+
+The `pulsar-perf` supports to connect to Pulsar cluster through OAuth2, as shown below:
+
+```shell script
+bin/pulsar-perf produce --service-url pulsar+ssl://cloud.streamnative.dev:6651 \
+  --auth_plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+  --auth-params '{"privateKey":"file:///path/to/key/file.txt",
+    "issuerUrl":"https://test.auth0.com",
+    "audience":"urn:sn:pulsar:test-pulsar-instance-namespace:test-pulsar-instance"}' \
+  -r 1000 -s 1024 test-topic
+```
+
+Output:
+
+```text
+...
+12:12:39.350 [pulsar-client-io-2-8] INFO  org.apache.pulsar.client.impl.PartitionedProducerImpl - [test-topic] Created partitioned producer
+12:12:39.351 [pulsar-perf-producer-exec-1-1] INFO  org.apache.pulsar.testclient.PerformanceProducer - Created 1 producers
+12:12:39.379 [pulsar-timer-7-1] WARN  com.scurrilous.circe.checksum.Crc32cIntChecksum - Failed to load Circe JNI library. Falling back to Java based CRC32c provider
+12:12:39.784 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Throughput produced:      0.1  msg/s ---      0.0 Mbit/s --- failure      0.0 msg/s --- Latency: mean:   0.000 ms - med:   0.000 - 95pct:   0.000 - 99pct:   0.000 - 99.9pct:   0.000 - 99.99pct:   0.000 - Max:   0.000
+12:12:49.854 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Throughput produced:    191.4  msg/s ---      1.5 Mbit/s --- failure      0.0 msg/s --- Latency: mean: 4647.764 ms - med: 5022.815 - 95pct: 7667.007 - 99pct: 7740.223 - 99.9pct: 7755.263 - 99.99pct: 7756.639 - Max: 7756.639
+12:12:59.894 [main] INFO  org.apache.pulsar.testclient.PerformanceProducer - Throughput produced:    900.4  msg/s ---      7.0 Mbit/s --- failure      0.0 msg/s --- Latency: mean: 1148.746 ms - med: 1093.679 -
+...
+```

--- a/cloud/pulsar-client/README.md
+++ b/cloud/pulsar-client/README.md
@@ -14,6 +14,8 @@ The `pulsar-client` and `pulsar-perf` are CLI tool written in Java language for 
 
 ## pulsar-client
 
+### Token authentication plugin
+
 The `pulsar-client` supports to connect to Pulsar cluster through Token, as shown below:
 
 ```shell script
@@ -31,13 +33,15 @@ Output:
 12:21:50.920 [main] INFO  org.apache.pulsar.client.cli.PulsarClientTool - 10 messages successfully produced
 ```
 
+### OAuth2 authentication plugin
+
 The `pulsar-client` supports to connect to Pulsar cluster through OAuth2, as shown below:
 
 ```shell script
 bin/pulsar-client \
   --url SERVICE_URL \
   --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
-  --auth-params '{"privateKey":"file:///path/to/key/file.txt",
+  --auth-params '{"privateKey":"file:///path/to/key/file.json",
     "issuerUrl":"https://test.auth0.com",
     "audience":"urn:sn:pulsar:test-pulsar-instance-namespace:test-pulsar-instance"}' \
   produce test-topic -m "test-message" -n 10
@@ -51,6 +55,8 @@ Output:
 ```
 
 ## pulsar-perf
+
+### Token authentication plugin
 
 The `pulsar-perf` supports to connect to Pulsar cluster through Token, as shown below:
 
@@ -76,12 +82,14 @@ Output:
 ...
 ```
 
+### OAuth2 authentication plugin
+
 The `pulsar-perf` supports to connect to Pulsar cluster through OAuth2, as shown below:
 
 ```shell script
 bin/pulsar-perf produce --service-url pulsar+ssl://cloud.streamnative.dev:6651 \
   --auth_plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
-  --auth-params '{"privateKey":"file:///path/to/key/file.txt",
+  --auth-params '{"privateKey":"file:///path/to/key/file.json",
     "issuerUrl":"https://test.auth0.com",
     "audience":"urn:sn:pulsar:test-pulsar-instance-namespace:test-pulsar-instance"}' \
   -r 1000 -s 1024 test-topic

--- a/cloud/pulsarctl/README.md
+++ b/cloud/pulsarctl/README.md
@@ -43,7 +43,7 @@ $ pulsarctl oauth2 activate \
     --issuer-endpoint https://cloud.streamnative.dev \
     --client-id abcdefghigk0123456789 \
     --audience urn:sn:pulsar:pulsar-instance-ns:pulsar-instance-name \
-    --key-file /path/to/private/key/file.txt
+    --key-file /path/to/private/key/file.json
 ```
 
 Output:
@@ -61,7 +61,7 @@ $ pulsarctl namespaces list public \
     --issuer-endpoint https://cloud.streamnative.dev \
     --client-id abcdefghigk0123456789 \
     --audience urn:sn:pulsar:pulsar-instance-ns:pulsar-instance-name \
-    --key-file /path/to/private/key/file.txt
+    --key-file /path/to/private/key/file.json
 ```
 
 Output:
@@ -81,7 +81,7 @@ The `pulsarctl` itself provides the function of the Go Admin API. You can use th
 ```shell script
 $ go build pulsarctl pulsarctl.go
 $ ./pulsarctl -webServiceURL https://cloud.streamnative.dev:443 \
-         -privateKeyFile /path/to/private/key/file.txt\
+         -privateKeyFile /path/to/private/key/file.json\
          -audience urn:sn:pulsar:pulsar-instance-ns:pulsar-instance-name\
          -issuerUrl https://cloud.streamnative.dev\
          -clientId abcdefghigk0123456789


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

- Fix the token examples of CLI tools
- Add the example of pulsar-client for connecting to a cluster either through Oauth2
- Add the example of pulsar-admin for connecting to a cluster either through Oauth2
- Add the example of pulsar-perf for connecting to a cluster either through Oauth2