### PR TITLE
update readme

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -8,8 +8,6 @@ This directory includes examples of how Pulsar CLI tools and Pulsar clients conn
   - [pulsar-client](https://github.com/streamnative/pulsar-examples/tree/master/cloud/pulsar-client)
   - [pulsar-perf](https://github.com/streamnative/pulsar-examples/tree/master/cloud/pulsar-client)
 
-  **Note**
-
 - Supported Pulsar clients
   - [Java client](https://github.com/streamnative/pulsar-examples/tree/master/cloud/java)
   - [C++ client](https://github.com/streamnative/pulsar-examples/tree/master/cloud/cpp)

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -10,8 +10,6 @@ This directory includes examples of how Pulsar CLI tools and Pulsar clients conn
 
   **Note**
 
-  > Currently, pulsarctl and pulsar-admin support to connect to a cluster either through Oauth2 or through the token. Other CLI tools only support to connect to a cluster through the token.
-
 - Supported Pulsar clients
   - [Java client](https://github.com/streamnative/pulsar-examples/tree/master/cloud/java)
   - [C++ client](https://github.com/streamnative/pulsar-examples/tree/master/cloud/cpp)


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Currently, all CLI tools support to connect to a cluster either through Oauth2 or through the token, so remove this.